### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/graphiqparser/__init__.py
+++ b/graphiqparser/__init__.py
@@ -253,7 +253,7 @@ PARSED TOKENS:    %s
 UNCERTAIN LABEL:  %s
 When this error is raised, it's likely that either (1) the string is not a valid person/corporation name or (2) some tokens were labeled incorrectly
 To report an error in labeling a valid name, open an issue at https://github.com/datamade/probablepeople/issues/new - it'll help us continue to improve probablepeople!
-For more information, see the documentation at http://probablepeople.readthedocs.org/
+For more information, see the documentation at https://probablepeople.readthedocs.io/
         '''%(original_string, parsed_string, repeated_label)
 
         super(RepeatedLabelError, self).__init__(message)


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
